### PR TITLE
middlewareの設定

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -1,9 +1,31 @@
-const GITHUB_TOKEN = process.env.REACT_APP_GITHUB_TOKEN
+import { ApolloProvider } from 'react-apollo'
+import { gql } from 'graphql-tag';
+import client from './client'
+import { Query } from 'react-apollo';
+
+const ME = gql`
+  query me {
+    user(login: "yunosuke924"){
+      name
+      avatarUrl
+    }
+  }
+`
 function App() {
   return (
-    <div>
-      hi GraphQL
-    </div>
+    <ApolloProvider client={client}>
+      <div>
+        hi GraphQL
+      </div>
+      <Query query={ME}>{
+        ({loading,error,data})=>{
+          if (loading) return 'Loading...'
+          if (error) return `Error! ${error.message}`
+          return <div>{data.user.name}</div>
+        }
+      }</Query>
+      </ApolloProvider>
+    
   )
 }
 

--- a/src/client.js
+++ b/src/client.js
@@ -1,0 +1,26 @@
+import { ApolloClient } from "apollo-client"
+import { ApolloLink } from "apollo-link"
+import { HttpLink } from "apollo-link-http"
+import { InMemoryCache } from "apollo-cache-inmemory"
+
+
+const GITHUB_TOKEN = process.env.REACT_APP_GITHUB_TOKEN
+
+const headersLink = new ApolloLink((operation, forward)=>{
+  operation.setContext({
+    headers:{
+      Authorization: `Bearer ${GITHUB_TOKEN}`
+    }
+  })
+  return forward(operation)
+})
+
+const endpoint = 'https://api.github.com/graphql'
+const httplink = new HttpLink({uri:endpoint})
+const link = ApolloLink.from([headersLink,httplink])
+
+export default new ApolloClient({
+  link,
+  cache: new InMemoryCache()
+})
+


### PR DESCRIPTION
クエリを記述するバッククォートの中で文字列を表現する時はダブルクォートで囲まないといけない。